### PR TITLE
fix: z-index for search bar on mobile

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -9,7 +9,7 @@ import blurIndigoImage from '@/images/blur-indigo.webp'
 export function Hero() {
   return (
     <div className="overflow-hidden bg-slate-900 dark:-mb-32 dark:mt-[-4.5rem] dark:pb-32 dark:pt-[4.5rem] dark:lg:mt-[-4.75rem] dark:lg:pt-[4.75rem]">
-      <div className="relative z-50 hidden max-sm:block w-3/4 px-4 pt-2 mx-auto">
+      <div className="relative hidden max-sm:block w-3/4 px-4 pt-2 mx-auto">
         <Nip05SearchBar></Nip05SearchBar>
       </div>
       <div className="pt-14 pb-16 sm:px-2 lg:relative lg:pt-20 lg:px-0">


### PR DESCRIPTION
Remove `z-50` class on small screen for search bar so it doesn't overlap the navbar