### PR TITLE
Make the search bar wider

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -9,7 +9,7 @@ import blurIndigoImage from '@/images/blur-indigo.webp'
 export function Hero() {
   return (
     <div className="overflow-hidden bg-slate-900 dark:-mb-32 dark:mt-[-4.5rem] dark:pb-32 dark:pt-[4.5rem] dark:lg:mt-[-4.75rem] dark:lg:pt-[4.75rem]">
-      <div className="relative hidden max-sm:block w-3/4 px-4 pt-2 mx-auto">
+      <div className="relative hidden max-sm:block px-4 pt-2 mx-8 mx-auto z-20">
         <Nip05SearchBar></Nip05SearchBar>
       </div>
       <div className="pt-14 pb-16 sm:px-2 lg:relative lg:pt-20 lg:px-0">

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -71,6 +71,7 @@ function Header({navigation}) {
           : 'dark:bg-transparent'
       )}
     >
+      <div className="relative flex mr-6">
       <div className="mr-6 flex lg:hidden">
         <MobileNavigation navigation={navigation} />
       </div>
@@ -88,8 +89,10 @@ function Header({navigation}) {
           </span>
         </Link>
       </div>
-      <div className="relative flex basis-0 items-center justify-end gap-2 sm:gap-4 md:flex-grow">
-        <div className="relative z-10 max-sm:hidden">
+
+      </div>
+      <div className="relative flex flex-auto basis-0 items-center justify-end gap-2 sm:gap-4 md:flex-grow">
+        <div className="relative z-10 max-sm:hidden sm:w-3/4 lg:w-1/2 lg:max-w-[40vw]">
           <Nip05SearchBar></Nip05SearchBar>
         </div>
           <ThemeSelector className="relative z-10" />


### PR DESCRIPTION
- Adds a little more width on the search bar on both mobile and desktop

- Fixes the previous z-index fix, as it was behind the background image div

![image](https://github.com/user-attachments/assets/36b83c8b-bfd5-4c8a-a89f-c847c4c6b29d)

![image](https://github.com/user-attachments/assets/e61adc2b-eeeb-4052-8cb5-ed43b116799d)

